### PR TITLE
relogin: added "www" to the website url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ open -na Google\ Chrome --args --user-data-dir=/tmp/temporary-chrome-profile-dir
 
 
 ## Troubleshooting
-1. To build `Android` APP you need to move two files: `google-services.json` -> `platforms/android/app` and `resources/android/xml/network_security_config.xml` -> `platforms/android/app/src/res/xml`
+1. To build `Android` APP you need to move two files: `google-services.json` -> `platforms/android/app` and `resources/android/xml/network_security_config.xml` -> `platforms/android/app/src/main/res/xml`

--- a/moodle.config.json
+++ b/moodle.config.json
@@ -30,7 +30,7 @@
     "sites": [
         {
             "name": "ISDA E-Learning School",
-            "url": "https://isdaelearning.com/"
+            "url": "https://www.isdaelearning.com/"
         }
     ],
     "multisitesdisplay": "",


### PR DESCRIPTION
The reason of this change is that in "loadSite" method there is `CoreLoginHelper.isSiteUrlAllowed(site.getURL(), false)` and this url and the url in moodle.config were mismatched: one has "www" but the second one doesn't have